### PR TITLE
UVa 10911 - Fix array smaller than input size

### DIFF
--- a/UVa 10911 - Forming Quiz Teams/src/UVa 10911 - Forming Quiz Teams.cpp
+++ b/UVa 10911 - Forming Quiz Teams/src/UVa 10911 - Forming Quiz Teams.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 
 double memo[(1 << 16)];
-int n, x[10], y[10];
+int n, x[16], y[16];
 
 double dist(int i, int j) {
 	return sqrt((x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]));


### PR DESCRIPTION
Max num of points is 16 there for the Xs and Ys arrays should be initialized with size of 16